### PR TITLE
Fix Flap bids in same block:

### DIFF
--- a/components/FlapAuctionBlock.js
+++ b/components/FlapAuctionBlock.js
@@ -179,6 +179,7 @@ const byTimestamp = (prev, next) => {
   if (nextTs > prevTs) return 1;
   if (nextTs < prevTs) return -1;
   if (nextTs === prevTs) {
+    if (next.type === 'Tend') return -1
     if (next.type === 'Dent') return 1;
     if (next.type === 'Deal') return 2;
     if (next.type === 'Kick') return -1;


### PR DESCRIPTION
- if Tend events have the same timestamp then return next event in sort by timestamp (API always returns proper order of events)
- can be tested with Auction ID: 1233 where we have 2 bids in same block / with same timestamp
{"auctionId": 1233, "type": "Tend", "hash": "0x937ff984e2bdc7bb40ea3b5f2c69e99748d6307cdb03ec03525d1aa7797d7757", "fromAddress": "0x067FB6b6ff920e3ed9eeE13808009BC2a6d5d736", "lot": 30000.0, "bid": 1e-18, "timestamp": 1637037397, "block": 13624542, "id": 2},
{"auctionId": 1233, "type": "Tend", "hash": "0x95603774c95442d7fdba7d012abaf52f20ab7e88aa462fdc6cd8c14859de5119", "fromAddress": "0x9922B1e0AB3b6a5C301b1DEEE1a53C12c2229620", "lot": 30000.0, "bid": 9.80392156862745, "timestamp": 1637037397, "block": 13624542, "id": 3}

![flap](https://user-images.githubusercontent.com/38490174/142167249-f9bd42be-bcb5-4ade-9d8b-e9edf9f3584f.png)
