### PR TITLE
Fix order for Tends in same block - take 2:

### DIFF
--- a/components/FlapAuctionBlock.js
+++ b/components/FlapAuctionBlock.js
@@ -179,6 +179,7 @@ const byTimestamp = (prev, next) => {
   if (nextTs > prevTs) return 1;
   if (nextTs < prevTs) return -1;
   if (nextTs === prevTs) {
+    if ((next.type === 'Tend') && (prev.type === 'Tend')) return -1
     if (next.type === 'Dent') return 1;
     if (next.type === 'Deal') return 2;
     if (next.type === 'Kick') return -1;


### PR DESCRIPTION
- previous fix was reverting order of events for Tend and Kick in same block, narrow the check only for 2 consecutive `Tend` events in same block / timestamp