### PR TITLE
When multiple events in same block, rely on id returned by API which …

### DIFF
--- a/components/FlapAuctionBlock.js
+++ b/components/FlapAuctionBlock.js
@@ -179,10 +179,7 @@ const byTimestamp = (prev, next) => {
   if (nextTs > prevTs) return 1;
   if (nextTs < prevTs) return -1;
   if (nextTs === prevTs) {
-    if ((next.type === 'Tend') && (prev.type === 'Tend')) return -1
-    if (next.type === 'Dent') return 1;
-    if (next.type === 'Deal') return 2;
-    if (next.type === 'Kick') return -1;
+    return next.id - prev.id;
   }
   return 0;
 };


### PR DESCRIPTION
…is always incrementing